### PR TITLE
Resolved linting errors in workflow yaml files.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
   schedule:
     - cron: '21 1 * * 2'
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,9 +3,9 @@ name: "Linting With Ruff"
 
 on:
   push:
-    branches: [ * ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,9 +3,9 @@ name: "Pytest"
 
 on:
   push:
-    branches: [ * ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ main ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,7 +3,7 @@ name: Sonarqube
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Workflow yaml files were not parseable due to the branch names. I have enclosed these in quotes to rectify this.

## Summary by Sourcery

CI:
- Enclosed branch names in quotes in multiple GitHub workflow files to resolve parsing issues