### PR TITLE
Resolved bug in which sonarqube action version was set incorrectly

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: sonarsource/sonarqube-scan-action@1.4.0
+      - uses: sonarsource/sonarqube-scan-action@v5.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
Sorcery.ai suggested setting the sonarqube workflow version but suggested a version that did not exist. This has not been resolved.

## Summary by Sourcery

Update SonarQube GitHub Action to the correct version

Bug Fixes:
- Corrected the SonarQube GitHub Action version from an incorrect 1.4.0 to the valid v5.1.0

CI:
- Updated the SonarQube scan action version in the GitHub workflow configuration