### PR TITLE
Corrected parth in Sonarqube config

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=petermcd_PIP-Security-Worker_16d5bf2f-e512-4b2d-bb0c-454f82721f17
-sonar.sources=./src
+sonar.sources=./pip_security_worker
 sonar.sourceEncoding=UTF-8
 sonar.language=python
 sonar.python.version=3.13


### PR DESCRIPTION
The sonar.sources was incorrectly set in sonar-project.properties. Updated to the correct path.

## Summary by Sourcery

Chores:
- Corrected the source path in sonar-project.properties to point to the correct project directory