### PR TITLE
23 implement adding items to the kafka queue

### DIFF
--- a/.github/workflows/uv.yml
+++ b/.github/workflows/uv.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run iSort
         run: uvx isort .
       - name: Run mypy
-        run: uvx --with types-PyYAML --with types-requests --with types-defusedxml --with types-python-dateutil mypy pip_security_worker
+        run: uvx --with types-PyYAML --with types-requests --with types-defusedxml --with types-python-dateutil mypy pip_security_worker tests

--- a/pip_security_worker/cli.py
+++ b/pip_security_worker/cli.py
@@ -6,16 +6,19 @@ import sys
 from pip_security_worker.helpers.exceptions import DatabaseConnectionError
 from pip_security_worker.helpers.neo4j_handler import Neo4jHandler
 from pip_security_worker.package_analysis.analyse import Analyse
+from pip_security_worker.package_analysis.fetch_tasks import FetchTasks
 from pip_security_worker.vulnerability_database.pip_advisory import PIPAdvisory
 
 LOG = logging.getLogger(__name__)
 
-def run_analyses() -> None:
+
+def run_analysis() -> None:
     """Run the analysis application."""
-    LOG.info('Running analyses')
+    LOG.info('Running analysis')
     Analyse()
 
-def run_update_db() -> None:
+
+def run_update_advisory_db() -> None:
     """Entry point to the application."""
     LOG.info('Updating advisory database')
 
@@ -30,3 +33,8 @@ def run_update_db() -> None:
             LOG.info(f'Adding advisory {advisory.advisory_id} for package {advisory.name} to the database')
             neo4j_handler.add_advisory(advisory=advisory)
 
+
+def run_recent_updated_packages() -> None:
+    """Entry point to the application."""
+    LOG.info('Fetching recently updated packages')
+    FetchTasks().update()

--- a/pip_security_worker/helpers/exceptions.py
+++ b/pip_security_worker/helpers/exceptions.py
@@ -3,14 +3,17 @@
 
 class DatabaseConnectionError(Exception):
     """NEO4j database connection error."""
+
     pass
 
 
 class GeneralError(Exception):
     """General error."""
+
     pass
 
 
 class NoTasksError(Exception):
     """Kafka topic has no tasks."""
+
     pass

--- a/pip_security_worker/helpers/helpers.py
+++ b/pip_security_worker/helpers/helpers.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime
-from json import loads
+from json import loads, JSONDecodeError
 from xml.parsers.expat import ExpatError
 from xmlrpc.client import DateTime
 
@@ -50,6 +50,9 @@ def fetch_next() -> Package | None:
     except StopIteration as exc:
         LOG.debug('No tasks waiting in Kafka.')
         raise NoTasksError('No tasks waiting.') from exc
+    except JSONDecodeError:
+        LOG.debug('Failed to decode JSON data')
+        raise NoTasksError('Task not in expected format.') from None
     finally:
         consumer.close()
 

--- a/pip_security_worker/helpers/neo4j_handler.py
+++ b/pip_security_worker/helpers/neo4j_handler.py
@@ -1,4 +1,5 @@
 """ "Neo4j handler."""
+
 import logging
 from json import dumps
 
@@ -11,6 +12,7 @@ from pip_security_worker.models.advisory import Advisory
 from pip_security_worker.models.package import Package
 
 LOG = logging.getLogger(__name__)
+
 
 class Neo4jHandler(object):
     __slots__ = ('_driver',)
@@ -28,7 +30,6 @@ class Neo4jHandler(object):
             LOG.critical('Failed to connect to Neo4j database')
             raise DatabaseConnectionError('Failed to connect to Neo4j database') from exc
 
-
     def add_advisory(self, advisory: Advisory) -> None:
         """
         Add an advisory to the database.
@@ -37,15 +38,15 @@ class Neo4jHandler(object):
             advisory (Advisory): The advisory to be added.
         """
         LOG.debug(f'Adding advisory {advisory.name} to database')
-        advisory_url: str = advisory.url or ""
-        security_types: str = advisory.security_type or ""
-        severity_score: str = advisory.severity_score or ""
+        advisory_url: str = advisory.url or ''
+        security_types: str = advisory.security_type or ''
+        severity_score: str = advisory.severity_score or ''
         self._driver.execute_query(
-            "MERGE (advisory:Advisory {name: $advisory_name, advisory_id: $advisory_id})" \
-            + "ON CREATE SET advisory.description = $advisory_description, advisory.published = $advisory_published," \
-            + "advisory.url = $advisory_url, advisory.raw = $advisory_raw," \
-            + "advisory.security_type = $advisory_security_type, advisory.severity_score = $advisory_severity_score," \
-            + "advisory.references = $advisory_references, advisory.versions = $advisory_versions",
+            'MERGE (advisory:Advisory {name: $advisory_name, advisory_id: $advisory_id})'
+            + 'ON CREATE SET advisory.description = $advisory_description, advisory.published = $advisory_published,'
+            + 'advisory.url = $advisory_url, advisory.raw = $advisory_raw,'
+            + 'advisory.security_type = $advisory_security_type, advisory.severity_score = $advisory_severity_score,'
+            + 'advisory.references = $advisory_references, advisory.versions = $advisory_versions',
             advisory_id=advisory.advisory_id,
             advisory_name=advisory.name,
             advisory_description=advisory.description,
@@ -68,14 +69,14 @@ class Neo4jHandler(object):
         """
         if not advisory.versions:
             LOG.debug(f'No affected versions found for advisory {advisory.name}')
-            #TODO identify what to do here.
+            # TODO identify what to do here.
             return
         for version in advisory.versions:
             self._driver.execute_query(
-                "MATCH(a: Advisory {name: $advisory_name, advisory_id: $advisory_id})" \
-                + "MATCH(p: Package {name: $advisory_name, version: $affects}) " \
-                + "MERGE(a)-[:affects]->(p)" \
-                + "MERGE(p)-[:affected_by]->(a)",
+                'MATCH(a: Advisory {name: $advisory_name, advisory_id: $advisory_id})'
+                + 'MATCH(p: Package {name: $advisory_name, version: $affects}) '
+                + 'MERGE(a)-[:affects]->(p)'
+                + 'MERGE(p)-[:affected_by]->(a)',
                 advisory_name=advisory.name,
                 affects=version,
                 advisory_id=advisory.advisory_id,
@@ -91,7 +92,7 @@ class Neo4jHandler(object):
         # TODO fully implement
         LOG.debug(f'Adding package {package.name} to database')
         self._driver.execute_query(
-            "MERGE (advisory:Package {name: $package_name, version: $package_version})",
+            'MERGE (advisory:Package {name: $package_name, version: $package_version})',
             package_name=package.name,
             package_version=package.version,
         )

--- a/pip_security_worker/models/package.py
+++ b/pip_security_worker/models/package.py
@@ -1,7 +1,7 @@
 """Dataclass for package information."""
 
 from dataclasses import dataclass
-from xmlrpc.client import DateTime
+from datetime import datetime
 
 
 @dataclass
@@ -11,4 +11,4 @@ class Package(object):
     link: str
     name: str
     version: str
-    published: DateTime
+    published: datetime

--- a/pip_security_worker/package_analysis/analyse.py
+++ b/pip_security_worker/package_analysis/analyse.py
@@ -1,10 +1,12 @@
 """Code to analyze the requirements of a package."""
+
 import logging
 
 from pip_security_worker.helpers.helpers import fetch_next
 from pip_security_worker.models.package import Package
 
 LOG = logging.getLogger(__name__)
+
 
 class Analyse(object):
     """Class to analyze a package."""

--- a/pip_security_worker/package_analysis/fetch_tasks.py
+++ b/pip_security_worker/package_analysis/fetch_tasks.py
@@ -1,0 +1,33 @@
+""" "Fetch tasks."""
+
+import logging
+from json import dumps
+
+from kafka import KafkaProducer
+
+from pip_security_worker import settings
+from pip_security_worker.helpers.helpers import fetch_recent
+from pip_security_worker.models.package import Package
+
+LOG = logging.getLogger(__name__)
+
+
+class FetchTasks(object):
+    """Class to handle fetching new packages to analyse from the pypi update feed."""
+
+    def update(self) -> None:
+        """Fetch new packages to analyse from the pypi update feed."""
+        LOG.debug('Fetching new packages to analyse from the pypi update feed')
+        new_package_versions: list[Package] = fetch_recent()
+        # TODO identify if the packages have already been added
+        kafka_producer = KafkaProducer(bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS)
+        for package in new_package_versions:
+            pay_load = {
+                'package_name': package.name,
+                'package_version': package.version,
+                'package_link': package.link,
+                'published': package.published.isoformat(),
+            }
+            kafka_producer.send(settings.KAFKA_TOPIC, value=dumps(pay_load).encode('utf-8'))
+            kafka_producer.flush()
+        kafka_producer.close()

--- a/pip_security_worker/settings.py
+++ b/pip_security_worker/settings.py
@@ -1,4 +1,5 @@
 """Settings for pip_security_worker."""
+
 import os
 
 import sentry_sdk
@@ -26,9 +27,9 @@ NEO4J_PASSWORD = os.getenv('NEO4J_PASSWORD', 'neo4j')
 # GIT Configuration
 GIT_STORAGE = os.getenv('GIT_STORAGE', '/tmp/advisory_database/')
 
-#Sentry Configuration
+# Sentry Configuration
 
-if SENTRY_DSN:= os.getenv('SENTRY_DSN'):
+if SENTRY_DSN := os.getenv('SENTRY_DSN'):
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         send_default_pii=True,

--- a/pip_security_worker/vulnerability_database/pip_advisory.py
+++ b/pip_security_worker/vulnerability_database/pip_advisory.py
@@ -1,4 +1,5 @@
 """Class to analyze the pip advisory database."""
+
 import logging
 import os
 import shutil
@@ -14,6 +15,7 @@ from pip_security_worker.models.advisory import Advisory
 from pip_security_worker.settings import PIP_ADVISORY_DB_URL
 
 LOG = logging.getLogger(__name__)
+
 
 class PIPAdvisory(object):
     """Class to analyze the pip advisory database."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,9 @@ Issues = "https://github.com/petermcd/PIP-Security-Worker/issues"
 packages = ["pip_security_worker"]
 
 [project.scripts]
-analyse = "pip_security_worker.cli:run_analyses"
-update_db = "pip_security_worker.cli:run_update_db"
+analyse = "pip_security_worker.cli:run_analysis"
+update_advisory_db = "pip_security_worker.cli:run_update_advisory_db"
+updated_packages = "pip_security_worker.cli:run_recent_updated_packages"
 
 [tool.ruff]
 
@@ -64,5 +65,5 @@ quote-style = "single"
 
 [tool.mypt.overrides]
 [[tool.mypy.overrides]]
-module = ["dotenv.*", "kafka.*", "neo4j.*", "sentry_sdk.*"]
+module = ["dotenv.*", "kafka.*", "neo4j.*", "pytest.*", "sentry_sdk.*"]
 ignore_missing_imports = true

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,5 @@
+from datetime import datetime
 from unittest.mock import patch
-from xmlrpc.client import DateTime
 
 import pytest
 
@@ -8,9 +8,9 @@ from pip_security_worker.models.package import Package
 
 
 class MockedRequest(object):
-
     status_code = 400
     content: bytes = ''.encode('utf-8')
+
     def __init__(self, *args, **kwargs):
         if 'status_code' in kwargs:
             self.status_code = kwargs['status_code']
@@ -29,74 +29,75 @@ class MockedRequest(object):
 
 
 class TestHelpers(object):
-
     @pytest.mark.parametrize(
-        'status_code,xml_document,expected_packages',[
-        (
-            400,
-            '',
-            [],
-        ),
-        (
-            200,
-            './tests/test_data/malformed.xml',
-            [],
-        ),
-        (
-            200,
-            './tests/test_data/empty.xml',
-            [],
-        ),
-        (
-            200,
-            './tests/test_data/single.xml',
-            [
-                Package(
-                    name='bbbctl',
-                    version='0.3.2',
-                    link='https://pypi.org/project/bbbctl/0.3.2/',
-                    published=DateTime('Tue, 22 Apr 2025 15:09:38 GMT')
-                ),
-            ],
-        ),
-        (
-            200,
-            './tests/test_data/single_alt_url.xml',
-            [
-                Package(
-                    name='bbbctl',
-                    version='0.3.2',
-                    link='https://pypi.org/project/bbbctl/0.3.2',
-                    published=DateTime('Tue, 22 Apr 2025 15:09:38 GMT')
-                ),
-            ],
-        ),
-        (
-            200,
-            './tests/test_data/multiple.xml',
-            [
-                Package(
-                    name='flytekitplugins-papermill',
-                    version='1.14.8',
-                    link='https://pypi.org/project/flytekitplugins-papermill/1.14.8/',
-                    published=DateTime('Wed, 23 Apr 2025 06:58:26 GMT')
-                ),
-                Package(
-                    name='flytekitplugins-pandera',
-                    version='1.14.8',
-                    link='https://pypi.org/project/flytekitplugins-pandera/1.14.8/',
-                    published=DateTime('Wed, 23 Apr 2025 06:58:25 GMT')
-                ),
-                Package(
-                    name='flytekitplugins-openai',
-                    version='1.14.8',
-                    link='https://pypi.org/project/flytekitplugins-openai/1.14.8/',
-                    published=DateTime('Wed, 23 Apr 2025 06:58:24 GMT')
-                ),
-            ],
-        ),
-    ])
-    def test_fetch_recent(self, status_code: int, xml_document: str,expected_packages: list[Package]):
+        'status_code,xml_document,expected_packages',
+        [
+            (
+                400,
+                '',
+                [],
+            ),
+            (
+                200,
+                './tests/test_data/malformed.xml',
+                [],
+            ),
+            (
+                200,
+                './tests/test_data/empty.xml',
+                [],
+            ),
+            (
+                200,
+                './tests/test_data/single.xml',
+                [
+                    Package(
+                        name='bbbctl',
+                        version='0.3.2',
+                        link='https://pypi.org/project/bbbctl/0.3.2/',
+                        published=datetime.strptime('Tue, 22 Apr 2025 15:09:38 GMT', '%a, %d %b %Y %H:%M:%S GMT'),
+                    ),
+                ],
+            ),
+            (
+                200,
+                './tests/test_data/single_alt_url.xml',
+                [
+                    Package(
+                        name='bbbctl',
+                        version='0.3.2',
+                        link='https://pypi.org/project/bbbctl/0.3.2',
+                        published=datetime.strptime('Tue, 22 Apr 2025 15:09:38 GMT', '%a, %d %b %Y %H:%M:%S GMT'),
+                    ),
+                ],
+            ),
+            (
+                200,
+                './tests/test_data/multiple.xml',
+                [
+                    Package(
+                        name='flytekitplugins-papermill',
+                        version='1.14.8',
+                        link='https://pypi.org/project/flytekitplugins-papermill/1.14.8/',
+                        published=datetime.strptime('Wed, 23 Apr 2025 06:58:26 GMT', '%a, %d %b %Y %H:%M:%S GMT'),
+                    ),
+                    Package(
+                        name='flytekitplugins-pandera',
+                        version='1.14.8',
+                        link='https://pypi.org/project/flytekitplugins-pandera/1.14.8/',
+                        published=datetime.strptime('Wed, 23 Apr 2025 06:58:25 GMT', '%a, %d %b %Y %H:%M:%S GMT'),
+                    ),
+                    Package(
+                        name='flytekitplugins-openai',
+                        version='1.14.8',
+                        link='https://pypi.org/project/flytekitplugins-openai/1.14.8/',
+                        published=datetime.strptime('Wed, 23 Apr 2025 06:58:24 GMT', '%a, %d %b %Y %H:%M:%S GMT'),
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_fetch_recent(self, status_code: int, xml_document: str, expected_packages: list[Package]):
         with patch('requests.get', return_value=MockedRequest(status_code=status_code, xml_document=xml_document)):
             packages = fetch_recent()
         assert packages == expected_packages


### PR DESCRIPTION
Added functionality to fetch the list of the latest updated packages and add these to the Kafka topic.

## Summary by Sourcery

Implement functionality to fetch recently updated packages from PyPI and add them to a Kafka queue for further processing

New Features:
- Add a new method to fetch recently updated packages from PyPI RSS feed
- Implement Kafka producer to queue new package updates
- Create a new CLI command to trigger package update fetching

Enhancements:
- Refactor package and datetime handling in helper functions
- Improve error handling and logging in package fetching process

Tests:
- Add parametrized tests for package fetching from XML feed
- Add test for Kafka message parsing and package creation

Chores:
- Update project scripts and CLI commands
- Modify type hints and imports