### PR TITLE
Enhanced advisories to link to the main package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following are the commands useful for this project:
 uvx ruff format
 uvx ruff check
 uvx isort .
-uvx mypy pip_security_worker
+uvx uvx --with types-PyYAML --with types-requests --with types-defusedxml --with types-python-dateutil mypy pip_security_worker tests
 ```
 
 ## Configuration

--- a/pip_security_worker/helpers/helpers.py
+++ b/pip_security_worker/helpers/helpers.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime
-from json import loads, JSONDecodeError
+from json import JSONDecodeError, loads
 from xml.parsers.expat import ExpatError
 from xmlrpc.client import DateTime
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pip_security_worker.helpers.helpers import fetch_recent, fetch_next
+from pip_security_worker.helpers.helpers import fetch_next, fetch_recent
 from pip_security_worker.models.package import Package
 
 
@@ -27,8 +27,10 @@ class MockedRequest(object):
         with open(document, 'r') as fh:
             self.content = fh.read().encode('utf-8')
 
+
 class MockedKafkaItem(object):
     value = ''
+
     def __init__(self, *args, **kwargs):
         if 'value' in kwargs:
             self.value = kwargs['value']
@@ -112,17 +114,19 @@ class TestHelpers(object):
         'record,expected_package',
         [
             (
-                MockedKafkaItem(value=b'{"package_link": "https://pypi.org/project/Monzo-API/", "package_name": "monzo-api", "package_version": "1.2.0", "published": "2025-04-18T10:30:00.000Z"}'),
+                MockedKafkaItem(
+                    value=b'{"package_link": "https://pypi.org/project/Monzo-API/", "package_name": "monzo-api", "package_version": "1.2.0", "published": "2025-04-18T10:30:00.000Z"}'
+                ),
                 Package(
                     name='monzo-api',
                     version='1.2.0',
-                    link="https://pypi.org/project/Monzo-API/",
+                    link='https://pypi.org/project/Monzo-API/',
                     published=datetime(2025, 4, 18, 10, 30, tzinfo=timezone.utc),
-                )
+                ),
             ),
         ],
     )
-    def test_fetch_next(self, record: str ,expected_package: Package):
+    def test_fetch_next(self, record: str, expected_package: Package):
         with patch('kafka.KafkaConsumer.__init__', return_value=None):
             with patch('kafka.KafkaConsumer.close', return_value=None):
                 with patch('kafka.KafkaConsumer.__next__', return_value=record):


### PR DESCRIPTION
For easier management the advisories now also link to a node for the main package, this will help identify advisories that need to be checked in future.

## Summary by Sourcery

Enhance advisory-to-package linking in Neo4j by creating and relating main Package nodes, standardize Cypher queries for version links, update tests formatting, and expand type checking in README

Enhancements:
- Link advisories to main Package nodes in Neo4j and initialize history_analyzed property
- Standardize Cypher queries with consistent labels for advisories and package versions

Build:
- Expand mypy invocation in README to include additional type stub packages and checks for tests

Documentation:
- Update README with extended mypy flags for types-PyYAML, types-requests, types-defusedxml, and types-python-dateutil

Tests:
- Adjust test_helpers formatting, JSON fixture indentation, and method signature spacing to match updated handler behavior